### PR TITLE
docs: Rename Workload Identity Federation to Federated Robot Accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Workload Identity Federation Examples to Push/Pull container Images Without Secrets
+# Federated Robot Accounts Examples to Push/Pull container Images Without Secrets
 
-Repository with examples demonstrating how to use Harbor/8gears Container Registry with Workload Identity Federation, eliminating the need for static secrets in CI/CD pipelines and Kubernetes.
+Repository with examples demonstrating how to use Harbor/8gears Container Registry with Federated Robot Accounts, eliminating the need for static secrets in CI/CD pipelines and Kubernetes.
 
 ## Overview
 
-**Workload Identity Federation** allows Harbor to authenticate clients using short-lived JWTs instead of static robot account secrets. By establishing a trust relationship with an external Identity Provider (like GitHub Actions, GitLab CI, or Kubernetes), Harbor can validate tokens and map them to internal robot accounts based on specific claims.
+**Federated Robot Accounts** allow Harbor to authenticate clients using short-lived JWTs instead of static robot account secrets. By establishing a trust relationship with an external Identity Provider (like GitHub Actions, GitLab CI, or Kubernetes), Harbor can validate tokens and map them to internal robot accounts based on specific claims.
 
 ### Benefits
 
@@ -25,7 +25,7 @@ Repository with examples demonstrating how to use Harbor/8gears Container Regist
 
 ## credential-provider-harbor
 
-`credential-provider-harbor` is a Kubernetes kubelet credential provider plugin (KEP-4412) that uses Service Account tokens directly as Harbor registry passwords via Workload Identity Federation (FedIDP).
+`credential-provider-harbor` is a Kubernetes kubelet credential provider plugin (KEP-4412) that uses Service Account tokens directly as Harbor registry passwords via Federated Robot Accounts.
 
 The kubelet calls this binary via stdin/stdout protocol: it receives a `CredentialProviderRequest` containing a service account token and returns a `CredentialProviderResponse` with Basic Auth credentials (`jwt:<SA-token>`).
 
@@ -293,7 +293,7 @@ This example demonstrates how to authenticate to Harbor from a GitHub Actions wo
 See a [successful run example](https://github.com/container-registry/federated-idp-examples/actions/runs/19678450809).
 
 ```yaml
-name: Create Image and Push Using federated IDP
+name: Create Image and Push Using Federated Robot Account
 
 on:
   workflow_dispatch:
@@ -410,7 +410,7 @@ Here's an example of what a GitHub Actions OIDC token looks like:
   "runner_environment": "github-hosted",
   "sha": "15a5ebfa3fb5ddf10c4b4250e14496bec7f03a56",
   "sub": "repo:container-registry/federated-idp-examples:ref:refs/heads/main",
-  "workflow": "Create Image and Push Using federated IDP",
+  "workflow": "Create Image and Push Using Federated Robot Account",
   "workflow_ref": "container-registry/federated-idp-examples/.github/workflows/example_1.yml@refs/heads/main",
   "workflow_sha": "15a5ebfa3fb5ddf10c4b4250e14496bec7f03a56"
 }
@@ -569,7 +569,7 @@ Here's an example of what a GitLab CI OIDC token looks like:
 
 ## Kubernetes (k3s/k3d) Setup
 
-This section describes how to set up a local k3s/k3d cluster with Kubernetes Image Credential Provider (KEP-4412) to pull images using Service Account tokens (Workload Identity Federation).
+This section describes how to set up a local k3s/k3d cluster with Kubernetes Image Credential Provider (KEP-4412) to pull images using Service Account tokens (Federated Robot Accounts).
 
 ### How It Works
 

--- a/cmd/credential-provider-harbor/README.md
+++ b/cmd/credential-provider-harbor/README.md
@@ -1,6 +1,6 @@
 credential-provider-harbor is an image credential provider plugin for Kubernetes
 that uses service account tokens directly as Harbor registry passwords via
-Workload Identity Federation (FedIDP).
+Federated Robot Accounts.
 
 Usage:
 

--- a/deploy/helm/credential-provider-harbor/Chart.yaml
+++ b/deploy/helm/credential-provider-harbor/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: credential-provider-harbor
-description: Deploy the credential-provider-harbor binary to Kubernetes nodes for Harbor Workload Identity Federation
+description: Deploy the credential-provider-harbor binary to Kubernetes nodes for Harbor Federated Robot Accounts
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.0.1"
 keywords:
   - harbor
   - credential-provider
-  - workload-identity
+  - federated-robot-accounts
   - fedidp
   - kubernetes
   - kubelet

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-This directory contains copy-paste starting points for Harbor Workload Identity Federation.
+This directory contains copy-paste starting points for Harbor Federated Robot Accounts.
 
 ## Available Examples
 

--- a/examples/github-actions/example_1.yml
+++ b/examples/github-actions/example_1.yml
@@ -1,4 +1,4 @@
-name: Create Image and Push Using federated IDP
+name: Create Image and Push Using Federated Robot Account
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Renames the feature naming throughout the repo content, following the rename in Harbor Next (container-registry/8gcr#356, container-registry/harbor-next#769):

- **"Workload Identity Federation" / "(FedIDP)"** as the feature name → **"Federated Robot Accounts"** — the end product the user is after; the federated identity provider connection is the means to it
- Example workflow name "Create Image and Push Using federated IDP" → "... Using Federated Robot Account"

Unchanged:
- Provider references stay as-is ("Harbor Federated IDP", "Configure a Federated Identity Provider in Harbor", ...) — the thing you connect is a federated identity provider
- Repository name, Go module path, chart name, URLs, image file paths, and real token-claim sample data

Also bumps the Helm chart to 0.1.1 since its metadata (description, keywords) changed and the chart is published to OCI on release.